### PR TITLE
Remove GameAnalytics API log filtering

### DIFF
--- a/ARK-Ascended-Server-Manager.py
+++ b/ARK-Ascended-Server-Manager.py
@@ -3449,8 +3449,6 @@ class ServerManagerApp:
         # Hide GameAnalytics spam (all severities)
         if "GameAnalytics" in s:
             return True
-        if "api.gameanalytics.com" in s:
-            return True
 
         return False
 


### PR DESCRIPTION
Removed filtering condition for 'api.gameanalytics.com' from logs.